### PR TITLE
Fix compilation error caused by missing declaration of cupsBackChannelRead

### DIFF
--- a/src/common/CupsPrintEnvironment.cpp
+++ b/src/common/CupsPrintEnvironment.cpp
@@ -23,6 +23,7 @@
 #include "CupsPrintEnvironment.h"
 #include <errno.h>
 #include <cups/cups.h>
+#include <cups/sidechannel.h>
 #include <cassert>
 
 namespace DymoPrinterDriver


### PR DESCRIPTION
Building `lw` no longer succeeds; it says
```
g++ -DHAVE_CONFIG_H -I. -I../../src -I../common    -O2 -Wall -Wno-unknown-pragmas   -MT CupsPrintEnvironment.o -MD -MP -MF .deps/CupsPrintEnvironment.Tpo -c -o CupsPrintEnvironment.o `test -f '../common/CupsPrintEnvironment.cpp' || echo './'`../common/CupsPrintEnvironment.cpp
../common/CupsPrintEnvironment.cpp: In member function ‘virtual void DymoPrinterDriver::CCupsPrintEnvironmentForLM::ReadData(DymoPrinterDriver::buffer_t&)’:
../common/CupsPrintEnvironment.cpp:139:23: error: ‘cupsBackChannelRead’ was not declared in this scope
  139 |   ssize_t bytesRead = cupsBackChannelRead((char*)buf, sizeof(buf), 2.5);
      |                       ^~~~~~~~~~~~~~~~~~~
make[4]: *** [Makefile:494: CupsPrintEnvironment.o] Error 1
```

Maybe `cupsBackChannelRead` is no longer declared in `<cups/cups.h>`?  Anyway with this change the compilation succeeds.
